### PR TITLE
add word wrap fix to entire container (#97)

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -9,10 +9,10 @@
     background-color: transparent;
     z-index: 16777271!important;
     position: absolute!important;
+    word-wrap: break-word;
 }
 
 .survol-container h1 {
-    word-wrap: break-word;
     line-height: 24px;
 }
 

--- a/css/base.css
+++ b/css/base.css
@@ -11,6 +11,11 @@
     position: absolute!important;
 }
 
+.survol-container h1 {
+    word-wrap: break-word;
+    line-height: 24px;
+}
+
 .survol-tooltiptext-youtube {
     width: 560px!important;
     height: 315px!important;

--- a/css/templates/wikipedia.css
+++ b/css/templates/wikipedia.css
@@ -41,12 +41,13 @@
     font-style: bold;
     font-size: 24px;
     margin-bottom: 12px;
+    line-height: 24px;
 }
 
 .survol-wikipedia-text p,
 .survol-wikipedia-text h1 {
     margin: 8px;
     color: rgb(0, 0, 0)!important;
-    text-align: justify!important;
-    text-justify: auto!important;
+    text-align: left!important;
+    /* text-justify: auto!important;*/
 }

--- a/js/templates/wikipedia.js
+++ b/js/templates/wikipedia.js
@@ -22,6 +22,11 @@ class WikipediaHover {
         }
     }
 
+    stripHTML(html) {
+        let doc = new DOMParser().parseFromString(html, 'text/html');
+        return doc.body.textContent || '';
+    }
+
     bindToContainer(node, domain, container) {
         if (this.linkType == 'article') {
 
@@ -47,7 +52,7 @@ class WikipediaHover {
                     }
 
                     let title = document.createElement('h1');
-                    title.appendChild(document.createTextNode(res.data.displaytitle.replace(/<\/?i>/g, '')));
+                    title.appendChild(document.createTextNode(this.stripHTML(res.data.displaytitle)));
 
                     let textContainer = document.createElement('div');
                     textContainer.className = 'survol-wikipedia-text';

--- a/js/templates/wikipedia.js
+++ b/js/templates/wikipedia.js
@@ -47,8 +47,8 @@ class WikipediaHover {
                     }
 
                     let title = document.createElement('h1');
-                    title.appendChild(document.createTextNode(res.data.displaytitle));
-
+                    title.appendChild(document.createTextNode(res.data.displaytitle.replace(/<\/?i>/g, '')));
+                    
                     let textContainer = document.createElement('div');
                     textContainer.className = 'survol-wikipedia-text';
 

--- a/js/templates/wikipedia.js
+++ b/js/templates/wikipedia.js
@@ -48,7 +48,7 @@ class WikipediaHover {
 
                     let title = document.createElement('h1');
                     title.appendChild(document.createTextNode(res.data.displaytitle.replace(/<\/?i>/g, '')));
-                    
+
                     let textContainer = document.createElement('div');
                     textContainer.className = 'survol-wikipedia-text';
 


### PR DESCRIPTION
This will resolve issue #97 

Hi, I've added a CSS fix for links not wrapping inside the container. The fix applied to both the title and the text container. So, this is roughly what it looks like when there is a link in the content.

<img width="446" alt="Screenshot 2020-10-08 at 23 00 00" src="https://user-images.githubusercontent.com/35401262/95519067-47522700-09bc-11eb-9c1e-c180f9560c1b.png">

I also spotted another issue with the title on Wikipedia preview - the title contained `i` tags as you can see in the screenshot below. I used regex to get rid of those.
<img width="446" alt="Screenshot 2020-10-08 at 23 00 56" src="https://user-images.githubusercontent.com/35401262/95519053-415c4600-09bc-11eb-8b30-998abc5f6cb2.png">

Let me know what you think!