### PR TITLE
Fix survol container getting out of height (issue #96)

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -13,6 +13,7 @@
     z-index: 16777271!important;
     position: absolute!important;
     word-wrap: break-word;
+    overflow: hidden;
 }
 
 .survol-container.dark-theme {

--- a/js/core.js
+++ b/js/core.js
@@ -104,10 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         container.innerHTML = '';
                     }
                 }
-                //get the popup dimensions or set a default value if dimensions are initially null
-                let popupWidth = container.clientWidth || 320;
-                //sets min-height of 320 if height is < 320px
-                let popupHeight = container.clientHeight > 320 ? container.clientHeight : 320;
+                //get the popup width
+                let popupWidth = container.clientWidth;
 
                 //get the current scroll distance
                 let scrolled = window.pageYOffset || (document.documentElement || document.body.parentNode || document.body).scrollTop;
@@ -116,19 +114,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 //if the current mouse X position plus the popup width is greater than the width of the viewport set the popup to the left, else right
                 let leftPosition = (e.pageX + popupWidth + buffer >= window.innerWidth) ? `${e.pageX - (popupWidth + buffer)}px` : `${e.pageX + buffer}px`;
                 //if the current mouse Y position is in the bottom half of the screen, set the popup above mouse, else below
-                let topPosition = ((e.pageY - scrolled) >= window.innerHeight / 2) ? `${e.pageY - (popupHeight + buffer)}px` : `${e.pageY + buffer}px`;
+                let topPosition = ((e.pageY - scrolled) >= window.innerHeight / 2) ? 0 : `${e.pageY + buffer}px`;
+                let bottomPosition = ((e.pageY - scrolled) >= window.innerHeight / 2) ? `${window.innerHeight - e.pageY + buffer}px` : 0;
 
                 //update the popup with the calculated values
                 container.style.left = leftPosition;
-                container.style.top = topPosition;
-                //sets min-height of popup
-                container.style.minHeight = '320px';
+                container.style.top = topPosition ? topPosition : 'auto';
+                container.style.bottom = bottomPosition ? bottomPosition : 'auto';
                 //sets max-height of popup to half height of window - buffer
                 container.style.maxHeight = `${(window.innerHeight / 2) - buffer}px`;
-
-                //only show the popup if there's content inside the container (stops box shadow from showing if there isn't)
-                container.style.display = container.innerHTML ? 'block' : 'none';
-                // setPopupPosition(container, e, buffer);
             });
 
             // Insert the container into the DOM

--- a/js/core.js
+++ b/js/core.js
@@ -1,9 +1,9 @@
 /* core.js is the heart of the extension.
  * It is a content script, injected on each page.
- * 
+ *
  * The core script injects the "survol-container" div into the DOM,
  * positions the div, and fill it with content.
- * 
+ *
  * It uses the mousemove event to detect when the cursor is hovering an anchor link (<a href>)
  * It is responsible for checking if this anchor link has an href, if the link should be
  * previewed or not, and which preview template should be used.
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     /* <https://www.chromium.org/Home/chromium-security/extension-content-script-fetches>
      * "Later in 2019, Extension Manifest V3 will become available, requiring cross-origin requests to occur in background pages rather than content scripts.  This new manifest version will have its own migration period, before support for Extension Manifest V2 is eventually removed from Chrome."
-     * 
+     *
      * Using the background script to pull data from APIs safely, i.e forwarding request from the content script to the background script
      * Direct asynchronous messaging, making it as a function to avoid having some request code across every file
      *
@@ -58,7 +58,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     /* insertSurvolDiv
-     * Parameters: 
+     * Parameters:
      * selfReferDisabled - {Boolean} - A setting to disable preview of inner links on a list of websites.
      *
      * This function:
@@ -104,23 +104,31 @@ document.addEventListener('DOMContentLoaded', () => {
                         container.innerHTML = '';
                     }
                 }
+                //get the popup dimensions or set a default value if dimensions are initially null
+                let popupWidth = container.clientWidth || 320;
+                //sets min-height of 320 if height is < 320px
+                let popupHeight = container.clientHeight > 320 ? container.clientHeight : 320;
 
-                //get the popup dims
-                let popupWidth = container.clientWidth;
-                let popupHeight = container.clientHeight;
                 //get the current scroll distance
                 let scrolled = window.pageYOffset || (document.documentElement || document.body.parentNode || document.body).scrollTop;
 
                 //calculate the popup positions
                 //if the current mouse X position plus the popup width is greater than the width of the viewport set the popup to the left, else right
                 let leftPosition = (e.pageX + popupWidth + buffer >= window.innerWidth) ? `${e.pageX - (popupWidth + buffer)}px` : `${e.pageX + buffer}px`;
-                //if the current mouse Y position (mius scroll distance) plus the popup height is greater than viewport height, set the popup above mouse, else below
-                let topPosition = ((e.pageY - scrolled) + popupHeight + buffer >= window.innerHeight) ? `${e.pageY - (popupHeight + buffer)}px` : `${e.pageY + buffer}px`;
+                //if the current mouse Y position is in the bottom half of the screen, set the popup above mouse, else below
+                let topPosition = ((e.pageY - scrolled) >= window.innerHeight / 2) ? `${e.pageY - (popupHeight + buffer)}px` : `${e.pageY + buffer}px`;
 
                 //update the popup with the calculated values
                 container.style.left = leftPosition;
                 container.style.top = topPosition;
+                //sets min-height of popup
+                container.style.minHeight = '320px';
+                //sets max-height of popup to half height of window - buffer
+                container.style.maxHeight = `${(window.innerHeight / 2) - buffer}px`;
 
+                //only show the popup if there's content inside the container (stops box shadow from showing if there isn't)
+                container.style.display = container.innerHTML ? 'block' : 'none';
+                // setPopupPosition(container, e, buffer);
             });
 
             // Insert the container into the DOM


### PR DESCRIPTION
Changes made:
- `js/base.js`
  - Noticed that because the `innerHTML` content doesn't load yet when hovering on a link, the popup height and width are both 0 (this was why the popup would initially appear below the mouse when it should appear above the mouse). I enforced a default value of 320px for each to set an initial popup position so this wouldn't happen.
  - Modified `topPosition` calculation so that if the mouse is in the bottom half of the screen, then the popup will appear above the mouse, otherwise it will appear below the mouse
  - Set min and max heights for the container (necessary as the `popupHeight` is initially null and can thus affect placement of the popup above or below the mouse)

- `css/base.css `
  - Added `overflow: hidden` rule to truncate popup's contents that may exceed the max height