### PR TITLE
Change the way Survol differentiates URLs, not only by domain, but also subdomain

### DIFF
--- a/css/onboarding/onboarding.css
+++ b/css/onboarding/onboarding.css
@@ -172,7 +172,7 @@ p {
     font-size: 18px;
 }
 
-#innerLinksList {
+#disabledList, #innerLinksList {
     max-width: 100%;
     width: 100%;
     border-radius: 6px;

--- a/html/onboarding.html
+++ b/html/onboarding.html
@@ -30,6 +30,11 @@
             </div>
             <br>
             <div>
+                <p>Survol disabled completely on :</p>
+                <textarea id="disabledList" placeholder="Comma separated list of domains"></textarea>
+            </div>
+            <br>
+            <div>
                 <p>Advanced setting - inner links preview disabled on :</p>
                 <textarea id="innerLinksList" placeholder="Comma separated list of domains on which you don't want inner links to be previewed e.g: github.com, ppy.sh, example.com, ...."></textarea>
             </div>

--- a/js/core.js
+++ b/js/core.js
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Description: Returns the domain name associated to a full link
      */
     function getDomain(link) {
-        return new URL(link).hostname;
+        return new URL(link).host;
     }
 
     /* getPotentialHover

--- a/js/core.js
+++ b/js/core.js
@@ -136,8 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Description: Returns the domain name associated to a full link
      */
     function getDomain(link) {
-        let subdomains = link.replace('http://', '').replace('https://', '').split('/')[0].split('.').length;
-        return link.replace('http://', '').replace('https://', '').split('/')[0].split('.').slice(subdomains - 2, subdomains).join('.');
+        return new URL(link).hostname;
     }
 
     /* getPotentialHover

--- a/js/popup/popup.js
+++ b/js/popup/popup.js
@@ -9,8 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Description: Returns the domain name associated to a full link
      */
     function getDomain(link) {
-        let subdomains = link.replace('http://', '').replace('https://', '').split('/')[0].split('.').length;
-        return link.replace('http://', '').replace('https://', '').split('/')[0].split('.').slice(subdomains - 2, subdomains).join('.');
+        return new URL(link).hostname;
     }
 
     ['pageSettings', 'generalSettings', 'enableOnPage'].forEach(function (word) {

--- a/js/popup/popup.js
+++ b/js/popup/popup.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
      * Description: Returns the domain name associated to a full link
      */
     function getDomain(link) {
-        return new URL(link).hostname;
+        return new URL(link).host;
     }
 
     ['pageSettings', 'generalSettings', 'enableOnPage'].forEach(function (word) {

--- a/js/templates/stackexchange.js
+++ b/js/templates/stackexchange.js
@@ -13,8 +13,7 @@ class StackExchangeHover {
      * Description: Returns the domain name associated to a full link
      */
     getDomain(link) {
-        let subdomains = link.replace('http://', '').replace('https://', '').split('/')[0].split('.').length;
-        return link.replace('http://', '').replace('https://', '').split('/')[0].split('.').slice(subdomains - 2, subdomains).join('.');
+        return new URL(link).hostname;
     }
 
     /* Description: This function is unique to every Hover class,

--- a/js/templates/stackexchange.js
+++ b/js/templates/stackexchange.js
@@ -13,7 +13,7 @@ class StackExchangeHover {
      * Description: Returns the domain name associated to a full link
      */
     getDomain(link) {
-        return new URL(link).hostname;
+        return new URL(link).host;
     }
 
     /* Description: This function is unique to every Hover class,

--- a/js/utils/bootstrap.js
+++ b/js/utils/bootstrap.js
@@ -35,6 +35,7 @@ const bootstrap = (function () {
                 document.getElementById('body').classList.add('dark-theme');
             }
 
+            document.getElementById('disabledList').value = disabledDomains.join(',');
             document.getElementById('innerLinksList').value = selfReferDisabled.join(',');
 
             switch (res.installationType) {
@@ -66,6 +67,10 @@ const bootstrap = (function () {
                     document.getElementById('darkThemeCheckbox').addEventListener('click', () => {
                         chrome.storage.local.set({ darkThemeToggle: document.getElementById('darkThemeCheckbox').checked });
                         document.getElementById('body').classList.toggle('dark-theme');
+                    });
+
+                    document.getElementById('disabledList').addEventListener('keyup', () => {
+                        chrome.storage.local.set({ disabledDomains: document.getElementById('disabledList').value.toLowerCase().replace(/ /g, '').split(',') });
                     });
 
                     document.getElementById('innerLinksList').addEventListener('keyup', () => {

--- a/js/utils/bootstrap.js
+++ b/js/utils/bootstrap.js
@@ -11,7 +11,7 @@ const bootstrap = (function () {
     }
 
     function getDomain(link) {
-        return new URL(link).hostname;
+        return new URL(link).host;
     }
 
     function updateUIElements(isPreviewMetadata, isDarkThemeChecked) {

--- a/js/utils/bootstrap.js
+++ b/js/utils/bootstrap.js
@@ -11,8 +11,7 @@ const bootstrap = (function () {
     }
 
     function getDomain(link) {
-        let subdomains = link.replace('http://', '').replace('https://', '').split('/')[0].split('.').length;
-        return link.replace('http://', '').replace('https://', '').split('/')[0].split('.').slice(subdomains - 2, subdomains).join('.');
+        return new URL(link).hostname;
     }
 
     function updateUIElements(isPreviewMetadata, isDarkThemeChecked) {


### PR DESCRIPTION
For example, [this](https://sample.netlify.app) and [this](https://vredeburg.netlify.app) are completely different website, although has same domain name. But, Survol treat those as same.
![](https://i.imgur.com/mTOsOTZ.jpg)

This changes will make Survol treat those websites different. So if you disable Survol on one page, the other page have no effect.