### PR TITLE
exclude credentials from fetch

### DIFF
--- a/js/background/auxiliary.js
+++ b/js/background/auxiliary.js
@@ -31,7 +31,7 @@ chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
 
         // If the request isn't cached
         else {
-            fetch(req.data.url)
+            fetch(req.data.url, {credentials: 'omit'})
                 .then((data) => { return req.data.noJSON ? data.text() : data.json(); })
                 .then((data) => {
                     res.data = data;


### PR DESCRIPTION
This extension installed by a someone in my company caused unwanted deletion of some products in our prestahop website. It seems unsafe to execute authenticated requests and might cause issues in a lot of cms admin pages. An exception was [previously added for wordpress](https://github.com/mdolr/survol/issues/105), but I propose to exclude credentials for all requests to prevent such issues.